### PR TITLE
Refactor box, Reduce nesting, split up function

### DIFF
--- a/maze_game/maze_game/Box.cs
+++ b/maze_game/maze_game/Box.cs
@@ -17,57 +17,67 @@ namespace maze_game
             {
                 for (int height = 0; height < ShapeSize.Height; height++)
                 {
-                    Console.SetCursorPosition(ShapePosition.X + width, ShapePosition.Y + height);
-                    if (width == 0 && height == 0)
-                    {
-                        Console.Write("╔");
-                    }
-                    else if (width == ShapeSize.Width - 1 && height == 0)
-                    {
-                        Console.Write("╗");
-                    }
-                    else if (width == 0 && height == ShapeSize.Height - 1)
-                    {
-                        Console.Write("╚");
-                    }
-                    else if (width == ShapeSize.Width - 1 && height == ShapeSize.Height - 1)
-                    {
-                        Console.Write("╝");
-                    }
-                    else if ((width == 0 || width == ShapeSize.Width - 1) && (height > 0 && height < ShapeSize.Height - 1))
-                    {
-                        if (isDialogue)
-                        {
-                            if (height == 2)
-                            {
-                                if (width == 0)
-                                {
-                                    Console.Write("╠");
-                                }
-                                else if (width == ShapeSize.Width - 1)
-                                {
-                                    Console.Write("╣");
-                                }
-                            }
-                            else
-                            {
-                                Console.Write("|");
-                            }
-                        }
-                        else
-                        {
-                            Console.Write("║");
-                        }
-                    }
-                    else if ((width > 0 && width < ShapeSize.Width - 1) && (height == 0 || height == ShapeSize.Height - 1))
-                    {
-                        Console.Write("=");
-                    }
-                    else
-                    {
-                        Console.Write(" ");
-                    }
+                    // Isn't a better name for width and height x and y? 
+                    // I am guessing its some form of coordinate system
+                    DrawCell(width, height, isDialogue);
                 }
+            }
+        }
+
+        private void DrawCell(int width, int height, bool isDialogue) {
+            Console.SetCursorPosition(ShapePosition.X + width, ShapePosition.Y + height);
+            if (width == 0 && height == 0)
+            {
+                Console.Write("╔");
+            }
+            else if (width == ShapeSize.Width - 1 && height == 0)
+            {
+                Console.Write("╗");
+            }
+            else if (width == 0 && height == ShapeSize.Height - 1)
+            {
+                Console.Write("╚");
+            }
+            else if (width == ShapeSize.Width - 1 && height == ShapeSize.Height - 1)
+            {
+                Console.Write("╝");
+            }
+            else if ((width == 0 || width == ShapeSize.Width - 1) && (height > 0 && height < ShapeSize.Height - 1))
+            {
+                if (isDialogue)
+                {
+                    DrawDialog();
+                }
+                else
+                {
+                    Console.Write("║");
+                }
+            }
+            else if ((width > 0 && width < ShapeSize.Width - 1) && (height == 0 || height == ShapeSize.Height - 1))
+            {
+                Console.Write("=");
+            }
+            else
+            {
+                Console.Write(" ");
+            }
+        }
+
+        private void DrawDialog() {
+            if (height == 2)
+            {
+                if (width == 0)
+                {
+                    Console.Write("╠");
+                }
+                else if (width == ShapeSize.Width - 1)
+                {
+                    Console.Write("╣");
+                }
+            }
+            else
+            {
+                Console.Write("|");
             }
         }
     }


### PR DESCRIPTION
It should not be called width and height, `x` and `y` would make more sense I think

I reduced nesting, in general, try not to go past 3 levels of nesting, every time you add a bracket, think of your team mates reading your code!!

See how I split up the `DrawDialog`? I am trying to cut it out and make it easier to read. In general, keep functions small, the longer the function the less you care about your team mates LOL. Maybe its ok if u are a fed Jax